### PR TITLE
Fix rails-style-guide reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1043,6 +1043,6 @@ or your pull requests will be closed.
 # Credit
 Inspiration was taken from the following:
 
-[howaboutwe's rspec style guide](https://github.com/howaboutwe/rspec-style-guide)
+[HowAboutWe's RSpec style guide](https://github.com/howaboutwe/rspec-style-guide)
 
-[bbatsov's rspec style guide](https://github.com/bbatsov/rails-style-guide)
+[Community Rails style guide](https://github.com/rubocop-hq/rails-style-guide)


### PR DESCRIPTION
The mentioned style guide is Rails, not RSpec. Not sure if the URL and even the name should reflect RuboCop HQ