### PR TITLE
Fix typo in an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -975,7 +975,7 @@ easier understanding and reading of a test.
       describe '#title' do
         it 'is unique' do
           another_article = FactoryGirl.create(:article, title: article.title)
-          article.valid?
+          another_article.valid?
           expect(another_article.errors[:title].size).to eq(1)
         end
       end


### PR DESCRIPTION
The example is running validation on the wrong object
Maybe we should replace `create` with `build` as well, or remove the `valid?` call, as the `create` will run the validations anyway