### PR TITLE
Gathered useful changes from stale branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ meant to be able to change with it.
 
   * <a name="empty-lines-after-describe"></a>
     Do not leave empty lines after `feature`, `context` or `describe`
-    descriptions. It does makes the code more difficult to read and lowers the
+    descriptions. It doesn't make the code more readable and lowers the
     value of logical chunks.
     <sup>[[link](#empty-lines-after-describe)]</sup>
 
@@ -168,8 +168,8 @@ meant to be able to change with it.
     ```
 
   * <a name="empty-lines-around-it"></a>
-    Leave one empty line around `it`/`specify` blocks. This helps to separate the
-    expectations from their conditional logic (contexts for instance).
+    Leave one empty line around `it`/`specify` blocks. This helps to separate
+    the expectations from their conditional logic (contexts for instance).
     <sup>[[link](#empty-lines-around-it)]</sup>
 
     ```ruby

--- a/README.md
+++ b/README.md
@@ -1195,8 +1195,26 @@ meant to be able to change with it.
 
 # Contributing
 
-Open tickets or send pull requests with improvements. Please write [good commit messages](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
-or your pull requests will be closed.
+Nothing written in this guide is set in stone. Everyone is welcome to
+contribute, so that we could ultimately create a resource that will be
+beneficial to the entire Ruby community.
+
+Feel free to open tickets or send pull requests with improvements.
+Thanks in advance for your help!
+
+You can also support the project (and RuboCop) with financial
+contributions via [Patreon](https://www.patreon.com/bbatsov).
+
+## How to Contribute?
+
+It's easy, just follow the contribution guidelines below.
+
+* [Fork](https://help.github.com/articles/fork-a-repo) the project on GitHub.
+* Make your feature addition or bug fix in a feature branch.
+* Include a [good description](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
+of your changes.
+* Push your feature branch to GitHub.
+* Send a [Pull Request](https://help.github.com/articles/using-pull-requests).
 
 # Credit
 

--- a/README.md
+++ b/README.md
@@ -1228,3 +1228,6 @@ Inspiration was taken from the following:
 [HowAboutWe's RSpec style guide](https://github.com/howaboutwe/rspec-style-guide)
 
 [Community Rails style guide](https://github.com/rubocop-hq/rails-style-guide)
+
+This guide was maintained by [ReachLocal](https://github.com/reachlocal)
+for a long while.

--- a/README.md
+++ b/README.md
@@ -1216,6 +1216,11 @@ of your changes.
 * Push your feature branch to GitHub.
 * Send a [Pull Request](https://help.github.com/articles/using-pull-requests).
 
+# License
+
+![Creative Commons License](http://i.creativecommons.org/l/by/3.0/88x31.png)
+This work is licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/deed.en_US)
+
 # Credit
 
 Inspiration was taken from the following:


### PR DESCRIPTION
Removed branches: `gh-pages`.
Borrowed small wording changes from `add_more_syntactical_style`.
Borrowed softened contribution guideline tone from `softened_tone` (and also `ruby-style-guide`/`rails-style-guide`).

Additionally:
 - added license information to match those of `ruby-style-guide` and `rails-style-guide`;
 - added credit to ReachLocal for long-term maintenance

Resolves #36 

- [ ] [Set up the license](https://github.com/rubocop-hq/rspec-style-guide/community/license/new?branch=master)