### PR TITLE
Fix mistake of using tilde instead of single quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,7 +708,7 @@ meant to be able to change with it.
 
     specify { is_expected.to be_truthy }
 
-    it '#do_something is deprecated` do
+    it '#do_something is deprecated' do
       ...
     end
 
@@ -723,7 +723,7 @@ meant to be able to change with it.
 
     it { is_expected.to be_truthy }
 
-    specify '#do_something is deprecated` do
+    specify '#do_something is deprecated' do
       ...
     end
     ```


### PR DESCRIPTION
Some ruby strings were being started with single quote but ended with tilde, which is invalid and screws up syntax highlighting.