### PR TITLE
Add reference to Effective Testing with RSpec 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ meant to be able to change with it.
   * <a name="ambiguous-hook-scope"></a>
     Use `:context` instead of the ambiguous `:all` scope in `before`/`after`
     hooks.
+    <a href="#etwr3">[etwr3, Ch 7]</a>
     <sup>[[link](#ambiguous-hook-scope)]</sup>
 
     ```ruby
@@ -1659,6 +1660,10 @@ meant to be able to change with it.
     # .rspec-local
     --profile 2
     ```
+
+# References
+
+* <a name="etwr3"></a> [etwr3] Myron Marston, Ian Dees. Effective Testing with RSpec 3. Pragmatic Bookshelf, 2017. ISBN 9781680501988.
 
 # Contributing
 


### PR DESCRIPTION
As discussed in #87.

I've gone for a style based on Martin Fowler's books – using an abbreviated name in the main body of the text.

From the book:

> RSpec 3 fixed the confusing wording by renaming :each to :example and :all to :context. The old names :each and :all are still there for backward compatibility with existing specs, but we recommend using only the newer terms.