### PR TITLE
Update wording for when to use `expect` syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ programmers.
 [`rubocop-rspec`](https://github.com/rubocop-hq/rubocop-rspec) extension,
 provides a way to enforce the rules outlined in this guide.
 
+This guide assumes you are using RSpec 3 or later.
+
 ## How to Read This Guide
 
 The guide is separated into sections based on the different pieces of an entire
@@ -1115,7 +1117,7 @@ meant to be able to change with it.
     ```
 
   * <a name="use-expect"></a>
-    On new projects always use the new `expect` syntax.
+    Always use the newer `expect` syntax.
     <sup>[[link](#use-expect)]</sup>
 
     Configure RSpec to only accept the new `expect` syntax.


### PR DESCRIPTION
Since it's been around for almost 7 years, it doesn't make sense to refer to the `expect` syntax as 'new'.

http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/