### PR TITLE
Fix typo in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1551,7 +1551,7 @@ describe '#title' do
 end
 ----
 
-=== Sepaate example group for attribute validations[[model-separate-describe-for-attribute-validations]]
+=== Separate example group for attribute validations[[model-separate-describe-for-attribute-validations]]
 
 Add a separate `describe` for each attribute which has validations.
 


### PR DESCRIPTION
Just a small typo I noticed. Thanks for the guide! 🙂 