### PR TITLE
Add Declare Constants guideline

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -947,6 +947,64 @@ context 'with unauthorized access' do
 end
 ----
 
+[#declare-constants]
+=== Declare Constants
+
+Do not explicitly declare classes, modules, or constants is example groups.
+https://relishapp.com/rspec/rspec-mocks/docs/mutating-constants[Stub constants instead].
+
+NOTE: Constants, including classes and modules, when declared in a block scope, are defined in global namespace, and leak between examples.
+
+[source,ruby]
+----
+# bad
+describe SomeClass do
+  CONSTANT_HERE = 'I leak into global namespace'
+end
+
+# good
+describe SomeClass do
+  before do
+    stub_const('CONSTANT_HERE', 'I only exist during this example')
+  end
+end
+
+# bad
+describe SomeClass do
+  class FooClass < described_class
+    def double_that
+      some_base_method * 2
+    end
+  end
+
+  it { expect(FooClass.new.double_that).to eq(4) }
+end
+
+# good - anonymous class, no constant needs to be defined
+let(:foo_class) do
+  Class.new(described_class) do
+    def double_that
+      some_base_method * 2
+    end
+  end
+
+  it { expect(foo_class.new.double_that).to eq(4) }
+end
+
+# good - constant is stubbed
+describe SomeClass do
+  before do
+    foo_class = Class.new(described_class) do
+                  def do_something
+                  end
+                end
+    stub_const('FooClass', foo_class)
+  end
+
+  it { expect(FooClass.new.double_that).to eq(4) }
+end
+----
+
 == Naming
 
 === Context Descriptions


### PR DESCRIPTION
Constants defined in a block are defined in a global namespace, and are not cleared up between examples.

If several examples may define a `DummyClass`, instead of being a blank slate class as it will be in the first example, subsequent examples will be reopening it and modifying its behaviour in unpredictable ways.
Even worse when a class that exists in the codebase is reopened.

Anonymous classes are fine since they don't result in global namespace name clashes.

Related [`RSpec/LeakyConstantDeclaration`](https://github.com/rubocop-hq/rubocop-rspec/pull/765) cop (follow the link for a lot of reasoning behind it).

More accessible representation of the added guideline https://github.com/rubocop-hq/rspec-style-guide/blob/add-leaky-constant-guideline/README.adoc#declare-constants