### PR TITLE
Add Implicit Block Expectation guideline

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1007,6 +1007,23 @@ describe SomeClass do
 end
 ----
 
+[#implicit-block-expectations]
+=== Implicit Block Expectations
+
+Avoid using implicit block expectations.
+
+[source,ruby]
+----
+# bad
+subject { -> { do_something } }
+it { is_expected.to change(something).to(new_value) }
+
+# good
+it 'changes something to a new value' do
+  expect { do_something }.to change(something).to(new_value)
+end
+----
+
 == Naming
 
 === Context Descriptions


### PR DESCRIPTION
Implicit syntax is discouraged to use by RSpec Core team and the majority of voters.

There were no good arguments for using the syntax except for brevity and avoiding repetition, but there are better options to achieve the same goal, e.g. by extracting the lengthy block to methods (instead of putting it inside the lambda).

Fixes #76

Better viewed as https://github.com/rubocop-hq/rspec-style-guide/blob/add-implicit-block-expectation-guideline/README.adoc#implicit-block-expectations

References:
https://www.reddit.com/r/ruby/comments/cejl3q/call_for_discussion_rspec_implicit_block/
https://blog.rubystyle.guide/rspec/2019/07/17/rspec-implicit-block-syntax.html
https://github.com/rubocop-hq/rspec-style-guide/issues/76
https://lobste.rs/s/e8yxmd/call_for_discussion_rspec_implicit_block