### PR TITLE
Fix typo at DRY section

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -821,7 +821,7 @@ end
 
 Be careful not to focus on being 'DRY' by moving repeated expectations into a shared environment too early, as this can lead to brittle tests that rely too much on one another.
 
-It general it is best to start with doing everything directly in your `it` blocks even if it is duplication and then refactor your tests after you have them working to be a little more DRY.
+In general, it is best to start with doing everything directly in your `it` blocks even if it is duplication and then refactor your tests after you have them working to be a little more DRY.
 However, keep in mind that duplication in test suites is NOT frowned upon, in fact it is preferred if it provides easier understanding and reading of a test.
 
 === Factories


### PR DESCRIPTION
It's simply a tiny typo error.
For a better community-driven documentation.